### PR TITLE
build.gradle:  suppress 54 deprecation warnings at build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ gradle.projectsEvaluated {
     tasks.withType(JavaCompile) { // compile-time options:
         options.compilerArgs << '-Xdiags:verbose'
         options.compilerArgs << '-Xlint:unchecked'
-        options.deprecation = true
+        //options.deprecation = true // to provide detailed deprecation warnings
         options.encoding = 'UTF-8'
     }
     tasks.withType(JavaExec) { // runtime options:


### PR DESCRIPTION
The application uses deprecated classes from JME's old animation system. The resulting flood of diagnostics makes it difficult to track down build-time errors. This PR suppresses the diagnostics.