### PR TITLE
DebugUtils:  resolve unmappable characters 0x93 and 0x94

### DIFF
--- a/src/main/java/com/capdevon/engine/DebugUtils.java
+++ b/src/main/java/com/capdevon/engine/DebugUtils.java
@@ -57,7 +57,7 @@ public class DebugUtils {
     /**
      * The coordinate axes (com.jme3.scene.debug.Arrow) help you see the
      * cardinal directions (X,Y,Z) from their center point. Scale the arrows to
-     * use them as a “ruler” for a certain length.
+     * use them as a "ruler" for a certain length.
      *
      * @param pos
      */


### PR DESCRIPTION
The buildscript specifies the source encoding as UTF-8. However source code includes instances of STS (code point U+0093) and CCH (code point U+0094), which cannot be mapped. This results in errors at compile time.

Assuming "smart quotes" were intended, this PR replaces both glyphs with QUO (U+0022).