### PR TITLE
AdapterControl:  suppress warning regarding an unchecked cast

### DIFF
--- a/src/main/java/com/capdevon/control/AdapterControl.java
+++ b/src/main/java/com/capdevon/control/AdapterControl.java
@@ -35,6 +35,7 @@ public class AdapterControl extends AbstractControl {
      * @param clazz
      * @return
      */
+    @SuppressWarnings("unchecked")
     public <T extends Control> T[] getComponents(Class<T> clazz) {
         final List<Node> lst = new ArrayList<>(10);
         spatial.breadthFirstTraversal(new SceneGraphVisitorAdapter() {


### PR DESCRIPTION
Since Java won't allocate generic arrays, it's difficult to avoid an "unchecked cast" warning at compile time.

This PR suppresses the warning to avoid distracting clutter during builds.