### PR TITLE
build.gradle:  shaderblow-ex must be in the classpath at compile time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     //runtimeOnly 'org.codehaus.groovy:groovy-jsr223:3.0.7'
     
     // Additional filters
-    runtimeOnly files('lib/shaderblow-ex-1.0.0.jar')
+    implementation files('lib/shaderblow-ex-1.0.0.jar')
     
     runtimeOnly files('lib/jme-materialize.jar')
 }


### PR DESCRIPTION
This PR resolves some compile-time errors caused by shaderblow-ex being absent from the classpath:
```console

> Task :compileJava FAILED
/home/sgold/NetBeansProjects/pr/Archer-Game-Template2/src/main/java/mygame/SceneAppState.java:3: error: package org.shaderblowex.filter does not exist
import org.shaderblowex.filter.MipmapBloomFilter;
                              ^
/home/sgold/NetBeansProjects/pr/Archer-Game-Template2/src/main/java/mygame/SceneAppState.java:107: error: cannot find symbol
        MipmapBloomFilter bloom = new MipmapBloomFilter(MipmapBloomFilter.Quality.High, MipmapBloomFilter.GlowMode.Scene);
        ^
  symbol:   class MipmapBloomFilter
  location: class SceneAppState
/home/sgold/NetBeansProjects/pr/Archer-Game-Template2/src/main/java/mygame/SceneAppState.java:107: error: cannot find symbol
        MipmapBloomFilter bloom = new MipmapBloomFilter(MipmapBloomFilter.Quality.High, MipmapBloomFilter.GlowMode.Scene);
                                      ^
  symbol:   class MipmapBloomFilter
  location: class SceneAppState
/home/sgold/NetBeansProjects/pr/Archer-Game-Template2/src/main/java/mygame/SceneAppState.java:107: error: package MipmapBloomFilter does not exist
        MipmapBloomFilter bloom = new MipmapBloomFilter(MipmapBloomFilter.Quality.High, MipmapBloomFilter.GlowMode.Scene);
                                                                         ^
/home/sgold/NetBeansProjects/pr/Archer-Game-Template2/src/main/java/mygame/SceneAppState.java:107: error: package MipmapBloomFilter does not exist
        MipmapBloomFilter bloom = new MipmapBloomFilter(MipmapBloomFilter.Quality.High, MipmapBloomFilter.GlowMode.Scene);
                                                                                                         ^
```