### PR TITLE
add a loading screen to the game

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,8 @@ dependencies {
     
     // Additional filters
     implementation files('lib/shaderblow-ex-1.0.0.jar')
-    
+
+    implementation 'com.github.stephengold:JmePower:1.0.0' // loading screen
     runtimeOnly files('lib/jme-materialize.jar')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     // Additional filters
     implementation files('lib/shaderblow-ex-1.0.0.jar')
 
-    implementation 'com.github.stephengold:JmePower:1.0.0' // loading screen
+    implementation 'com.github.stephengold:JmePower:1.1.0' // loading screen
     runtimeOnly files('lib/jme-materialize.jar')
 }
 

--- a/src/main/java/com/capdevon/engine/PrefabComponent.java
+++ b/src/main/java/com/capdevon/engine/PrefabComponent.java
@@ -12,12 +12,13 @@ import com.jme3.math.Vector3f;
 import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 import com.jme3.system.AppSettings;
+import jme3utilities.Loadable;
 
 /**
  * 
  * @author capdevon
  */
-public abstract class PrefabComponent {
+public abstract class PrefabComponent implements Loadable {
 
     public final Application app;
     public final AssetManager assetManager;

--- a/src/main/java/mygame/Main.java
+++ b/src/main/java/mygame/Main.java
@@ -4,9 +4,12 @@ import com.capdevon.input.GInputAppState;
 import com.capdevon.physx.Physics;
 import com.capdevon.physx.TogglePhysicsDebugState;
 import com.github.stephengold.jmepower.JmeLoadingState;
-import com.jme3.app.FlyCamAppState;
+import com.jme3.app.DebugKeysAppState;
 import com.jme3.app.SimpleApplication;
+import com.jme3.app.StatsAppState;
 import com.jme3.app.state.AppState;
+import com.jme3.app.state.ConstantVerifierState;
+import com.jme3.audio.AudioListenerState;
 import com.jme3.bullet.BulletAppState;
 import com.jme3.system.AppSettings;
 
@@ -24,6 +27,13 @@ import mygame.states.SceneAppState;
  * @author capdevon
  */
 public class Main extends SimpleApplication {
+
+    /**
+     * Construct the application instance but don't attach any appstates.
+     */
+    private Main() {
+        super((AppState[]) null);
+    }
 
     /**
      * Start the jMonkeyEngine application
@@ -98,9 +108,16 @@ public class Main extends SimpleApplication {
      * After the loading screen has completed, initialize the game.
      */
     private void startGame() {
-        // disable the default 1st-person flyCam!
-        stateManager.detach(stateManager.getState(FlyCamAppState.class));
-        flyCam.setEnabled(false);
+        /*
+         * Attach the appstates that SimpleApplication attaches by default,
+         * except for FlyCamAppState.
+         */
+        stateManager.attachAll(
+                new AudioListenerState(),
+                new ConstantVerifierState(),
+                new DebugKeysAppState(),
+                new StatsAppState()
+        );
 
         SoundManager.init(assetManager);
         stateManager.attach(new SceneAppState());

--- a/src/main/java/mygame/Main.java
+++ b/src/main/java/mygame/Main.java
@@ -16,7 +16,6 @@ import mygame.player.PlayerManager;
 import mygame.player.PlayerModel;
 import mygame.prefabs.ArrowPrefab;
 import mygame.prefabs.ExplosionPrefab;
-import mygame.prefabs.ExplosiveArrowPrefab;
 import mygame.prefabs.MyCubePrefab;
 import mygame.states.CubeAppState;
 import mygame.states.SceneAppState;
@@ -67,15 +66,15 @@ public class Main extends SimpleApplication {
         ePoison.assetName = "Scenes/jMonkey/Poison.j3o";
 
         Loadable[] preloadArray = new Loadable[]{
+            new PlayerModel(),
+            //new MonsterPrefab(this),
+            new ArrowPrefab(this),
             eFlame,
             ePoison,
+            new MyCubePrefab(this),
             AudioLib.ARROW_HIT,
             AudioLib.BOW_PULL,
-            AudioLib.GRASS_FOOTSTEPS,
-            new ArrowPrefab(this),
-            new MyCubePrefab(this),
-            new PlayerModel(),
-            //new MonsterPrefab(this) // WIP...
+            AudioLib.GRASS_FOOTSTEPS
         };
         JmeLoadingState loading = new JmeLoadingState(preloadArray);
         stateManager.attach(loading);

--- a/src/main/java/mygame/Main.java
+++ b/src/main/java/mygame/Main.java
@@ -17,6 +17,7 @@ import mygame.player.PlayerModel;
 import mygame.prefabs.ArrowPrefab;
 import mygame.prefabs.ExplosionPrefab;
 import mygame.prefabs.ExplosiveArrowPrefab;
+import mygame.prefabs.MyCubePrefab;
 import mygame.states.CubeAppState;
 import mygame.states.SceneAppState;
 
@@ -72,6 +73,7 @@ public class Main extends SimpleApplication {
             AudioLib.BOW_PULL,
             AudioLib.GRASS_FOOTSTEPS,
             new ArrowPrefab(this),
+            new MyCubePrefab(this),
             new PlayerModel(),
             //new MonsterPrefab(this) // WIP...
         };

--- a/src/main/java/mygame/Main.java
+++ b/src/main/java/mygame/Main.java
@@ -77,10 +77,11 @@ public class Main extends SimpleApplication {
 
         Loadable[] preloadArray = new Loadable[]{
             new PlayerModel(),
+            new SceneAppState(),
             //new MonsterPrefab(this),
-            new ArrowPrefab(this),
             eFlame,
             ePoison,
+            new ArrowPrefab(this),
             new MyCubePrefab(this),
             AudioLib.ARROW_HIT,
             AudioLib.BOW_PULL,

--- a/src/main/java/mygame/Main.java
+++ b/src/main/java/mygame/Main.java
@@ -72,7 +72,6 @@ public class Main extends SimpleApplication {
             AudioLib.BOW_PULL,
             AudioLib.GRASS_FOOTSTEPS,
             new ArrowPrefab(this),
-            new ExplosiveArrowPrefab(this),
             new PlayerModel(),
             //new MonsterPrefab(this) // WIP...
         };

--- a/src/main/java/mygame/audio/AudioClip.java
+++ b/src/main/java/mygame/audio/AudioClip.java
@@ -45,7 +45,10 @@ public class AudioClip implements Loadable {
      */
     @Override
     public void load(AssetManager assetManager) {
-        AudioKey key = new AudioKey(file, true, true); // TODO check this!
+        // Assume the clip will be buffered, not streamed. TODO
+        boolean stream = false;
+        boolean streamCache = true;
+        AudioKey key = new AudioKey(file, stream, streamCache);
         assetManager.loadAudio(key);
     }
 

--- a/src/main/java/mygame/audio/AudioClip.java
+++ b/src/main/java/mygame/audio/AudioClip.java
@@ -1,10 +1,15 @@
 package mygame.audio;
 
+import com.jme3.asset.AssetManager;
+import com.jme3.audio.AudioData;
+import com.jme3.audio.AudioKey;
+import jme3utilities.Loadable;
+
 /**
  *
  * @author capdevon
  */
-public class AudioClip {
+public class AudioClip implements Loadable {
 
     public String file;
     public float volume = 1;
@@ -31,6 +36,17 @@ public class AudioClip {
         this.volume = volume;
         this.looping = looping;
         this.positional = positional;
+    }
+
+    /**
+     * Preload the assets used in this clip.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        AudioKey key = new AudioKey(file, true, true); // TODO check this!
+        assetManager.loadAudio(key);
     }
 
     @Override

--- a/src/main/java/mygame/player/PlayerManager.java
+++ b/src/main/java/mygame/player/PlayerManager.java
@@ -1,10 +1,8 @@
 package mygame.player;
 
-import com.capdevon.anim.Animator;
 import com.capdevon.engine.SimpleAppState;
 import com.capdevon.input.GInputAppState;
 import com.capdevon.util.LineRenderer;
-import com.jme3.bullet.control.BetterCharacterControl;
 import com.jme3.font.BitmapFont;
 import com.jme3.font.BitmapText;
 import com.jme3.material.Material;
@@ -55,13 +53,8 @@ public class PlayerManager extends SimpleAppState {
     }
 
     private void setupPlayer() {
-        // Create a node for the character model
-        player = (Node) assetManager.loadModel("Models/Archer/Erika.j3o");
-        player.setName("Player");
-
-        // add Physics & Animation Control
-        player.addControl(new Animator());
-        player.addControl(new BetterCharacterControl(.4f, 1.8f, 80f));
+        PlayerModel model = new PlayerModel();
+        player = model.instantiate(assetManager);
         getPhysicsSpace().add(player);
         rootNode.attachChild(player);
 

--- a/src/main/java/mygame/player/PlayerModel.java
+++ b/src/main/java/mygame/player/PlayerModel.java
@@ -1,0 +1,45 @@
+package mygame.player;
+
+import com.capdevon.anim.Animator;
+import com.jme3.asset.AssetManager;
+import com.jme3.bullet.control.BetterCharacterControl;
+import com.jme3.scene.Node;
+import jme3utilities.Loadable;
+
+/**
+ * Encapsulate information about the player's character/avatar.
+ *
+ * @author sgold@sonic.net
+ */
+public class PlayerModel implements Loadable {
+
+    final static String ASSET_PATH = "Models/Archer/Erika.j3o";
+
+    /**
+     * Instantiate a 3-D model for the player's character/avatar.
+     *
+     * @param assetManager for loading assets (not null)
+     * @return a new Node
+     */
+    public Node instantiate(AssetManager assetManager) {
+        Node result = (Node) assetManager.loadModel(ASSET_PATH);
+        result.setName("Player");
+
+        // add Physics & Animation Control
+        result.addControl(new Animator());
+        result.addControl(new BetterCharacterControl(.4f, 1.8f, 80f));
+        
+        return result;
+    }
+
+    /**
+     * Preload the assets used in this model.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        // Create a node for the character model
+        assetManager.loadModel(ASSET_PATH);
+    }
+}

--- a/src/main/java/mygame/prefabs/ArrowPrefab.java
+++ b/src/main/java/mygame/prefabs/ArrowPrefab.java
@@ -1,6 +1,7 @@
 package mygame.prefabs;
 
 import com.jme3.app.Application;
+import com.jme3.asset.AssetManager;
 import com.jme3.bullet.collision.PhysicsCollisionObject;
 import com.jme3.bullet.collision.shapes.SphereCollisionShape;
 import com.jme3.bullet.control.RigidBodyControl;
@@ -18,6 +19,7 @@ import mygame.weapon.RangedBullet;
 public class ArrowPrefab extends RangedBullet {
 
     public float radius = 0.04f;
+    final static String ASSET_PATH = "Models/Arrow/arrow.glb";
 
     public ArrowPrefab(Application app) {
         super(app);
@@ -45,7 +47,7 @@ public class ArrowPrefab extends RangedBullet {
 
     @Override
     public Spatial instantiate(Vector3f position, Quaternion rotation, Node parent) {
-        Spatial model = assetManager.loadModel("Models/Arrow/arrow.glb");
+        Spatial model = assetManager.loadModel(ASSET_PATH);
         model.setName(name + "-" + nextSeqId());
         model.setLocalTranslation(position);
         model.setLocalRotation(rotation);
@@ -68,4 +70,13 @@ public class ArrowPrefab extends RangedBullet {
         return model;
     }
 
+    /**
+     * Preload the assets used in this prefab.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        assetManager.loadModel(ASSET_PATH);
+    }
 }

--- a/src/main/java/mygame/prefabs/ExplosionPrefab.java
+++ b/src/main/java/mygame/prefabs/ExplosionPrefab.java
@@ -2,7 +2,7 @@ package mygame.prefabs;
 
 import com.capdevon.engine.PrefabComponent;
 import com.jme3.app.Application;
-import com.jme3.light.Light;
+import com.jme3.asset.AssetManager;
 import com.jme3.light.PointLight;
 import com.jme3.math.ColorRGBA;
 import com.jme3.math.Quaternion;
@@ -67,5 +67,15 @@ public class ExplosionPrefab extends PrefabComponent {
         emitter.play();
 
         return model;
+    }
+
+    /**
+     * Preload the assets used in this prefab.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        assetManager.loadModel(assetName);
     }
 }

--- a/src/main/java/mygame/prefabs/ExplosiveArrowPrefab.java
+++ b/src/main/java/mygame/prefabs/ExplosiveArrowPrefab.java
@@ -1,6 +1,7 @@
 package mygame.prefabs;
 
 import com.jme3.app.Application;
+import com.jme3.asset.AssetManager;
 import com.jme3.bullet.collision.PhysicsCollisionObject;
 import com.jme3.bullet.collision.shapes.SphereCollisionShape;
 import com.jme3.bullet.control.RigidBodyControl;
@@ -20,6 +21,7 @@ public class ExplosiveArrowPrefab extends RangedBullet {
 
     public float radius = 0.04f;
     public ExplosionPrefab explosionPrefab;
+    final static String ASSET_PATH = "Models/Arrow/arrow.glb";
 
     public ExplosiveArrowPrefab(Application app) {
         super(app);
@@ -36,7 +38,7 @@ public class ExplosiveArrowPrefab extends RangedBullet {
 
     @Override
     public Spatial instantiate(Vector3f position, Quaternion rotation, Node parent) {
-        Spatial model = assetManager.loadModel("Models/Arrow/arrow.glb");
+        Spatial model = assetManager.loadModel(ASSET_PATH);
         model.setName(name + "-" + nextSeqId());
         model.setLocalTranslation(position);
         model.setLocalRotation(rotation);
@@ -59,4 +61,13 @@ public class ExplosiveArrowPrefab extends RangedBullet {
         return model;
     }
 
+    /**
+     * Preload the assets used in this prefab.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        assetManager.loadModel(ASSET_PATH);
+    }
 }

--- a/src/main/java/mygame/prefabs/MonsterPrefab.java
+++ b/src/main/java/mygame/prefabs/MonsterPrefab.java
@@ -3,6 +3,7 @@ package mygame.prefabs;
 import com.capdevon.anim.Animator;
 import com.capdevon.engine.PrefabComponent;
 import com.jme3.app.Application;
+import com.jme3.asset.AssetManager;
 import com.jme3.bullet.PhysicsSpace;
 import com.jme3.bullet.collision.PhysicsCollisionObject;
 import com.jme3.bullet.collision.shapes.CapsuleCollisionShape;
@@ -30,6 +31,7 @@ import mygame.weapon.Damageable;
  */
 public class MonsterPrefab extends PrefabComponent {
 
+    final static String ASSET_PATH = "Models/Drake.glb"; // WIP...
     public boolean usePhysics;
     public float radius = 0.4f;
     public float height = 1.6f;
@@ -44,7 +46,7 @@ public class MonsterPrefab extends PrefabComponent {
     @Override
     public Spatial instantiate(Vector3f position, Quaternion rotation, Node parent) {
 
-        Node enemy = (Node) assetManager.loadModel("Models/Drake.glb"); // WIP...
+        Node enemy = (Node) assetManager.loadModel(ASSET_PATH);
         enemy.setName("Monster-" + nextSeqId());
         enemy.setLocalTranslation(position);
         enemy.setLocalRotation(rotation);
@@ -115,4 +117,13 @@ public class MonsterPrefab extends PrefabComponent {
         return rbc;
     }
 
+    /**
+     * Preload the assets used in this prefab.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        assetManager.loadModel(ASSET_PATH);
+    }
 }

--- a/src/main/java/mygame/prefabs/MyCubePrefab.java
+++ b/src/main/java/mygame/prefabs/MyCubePrefab.java
@@ -29,6 +29,7 @@ public class MyCubePrefab extends PrefabComponent {
 
     public float size = 0.5f;
     public float mass = 30f;
+    final static String TEXTURE_ASSET_PATH = "Textures/github-logo.png";
 
     public MyCubePrefab(Application app) {
         super(app);
@@ -63,7 +64,7 @@ public class MyCubePrefab extends PrefabComponent {
     private Material getPBRLighting() {
         Material mat = new Material(assetManager, "Common/MatDefs/Light/PBRLighting.j3md");
         mat.setName("PBRLighting");
-        mat.setTexture("BaseColorMap", assetManager.loadTexture("Textures/github-logo.png"));
+        mat.setTexture("BaseColorMap", assetManager.loadTexture(TEXTURE_ASSET_PATH));
         mat.setFloat("Metallic", 0);
         mat.setFloat("Roughness", 0.4f);
         return mat;
@@ -72,7 +73,7 @@ public class MyCubePrefab extends PrefabComponent {
     private Material getMaterializePBR() {
         Material mat = new Material(assetManager, "MatDefs/Materialize/MaterializePBR.j3md");
         mat.setName("MaterializePBR");
-        mat.setTexture("BaseColorMap", assetManager.loadTexture("Textures/github-logo.png"));
+        mat.setTexture("BaseColorMap", assetManager.loadTexture(TEXTURE_ASSET_PATH));
         mat.setFloat("Roughness", 0.2f);
         mat.setFloat("Metallic", 0.001f);
         mat.setColor("EdgeColor", ColorRGBA.Red.mult(0.7f));
@@ -89,6 +90,6 @@ public class MyCubePrefab extends PrefabComponent {
      */
     @Override
     public void load(AssetManager assetManager) {
-        // do nothing
+        assetManager.loadTexture(TEXTURE_ASSET_PATH);
     }
 }

--- a/src/main/java/mygame/prefabs/MyCubePrefab.java
+++ b/src/main/java/mygame/prefabs/MyCubePrefab.java
@@ -2,6 +2,7 @@ package mygame.prefabs;
 
 import com.capdevon.engine.PrefabComponent;
 import com.jme3.app.Application;
+import com.jme3.asset.AssetManager;
 import com.jme3.bounding.BoundingBox;
 import com.jme3.bullet.collision.shapes.BoxCollisionShape;
 import com.jme3.bullet.collision.shapes.CollisionShape;
@@ -81,4 +82,13 @@ public class MyCubePrefab extends PrefabComponent {
         return mat;
     }
 
+    /**
+     * Preload the assets used in this prefab.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        // do nothing
+    }
 }

--- a/src/main/java/mygame/states/SceneAppState.java
+++ b/src/main/java/mygame/states/SceneAppState.java
@@ -3,6 +3,7 @@ package mygame.states;
 import org.shaderblowex.filter.MipmapBloomFilter;
 
 import com.capdevon.engine.SimpleAppState;
+import com.jme3.asset.AssetManager;
 import com.jme3.audio.AudioData;
 import com.jme3.audio.AudioNode;
 import com.jme3.bullet.PhysicsSpace;
@@ -23,12 +24,18 @@ import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.scene.Spatial;
 import com.jme3.shadow.DirectionalLightShadowRenderer;
 import com.jme3.util.SkyFactory;
+import jme3utilities.Loadable;
 
 /**
  *
  * @author capdevon
  */
-public class SceneAppState extends SimpleAppState {
+public class SceneAppState extends SimpleAppState implements Loadable {
+
+    final public static String AUDIO_ASSET_PATH = "Sound/Environment/Nature.ogg";
+    final public static String LIGHT_ASSET_PATH = "Scenes/defaultProbe.j3o";
+    final public static String MODEL_ASSET_PATH = "Scenes/level_rough.gltf";
+    final public static String SKY_ASSET_PATH = "Scenes/Beach/FullskiesSunset0068.dds";
 
     private DirectionalLight sun;
     private FilterPostProcessor fpp;
@@ -43,14 +50,29 @@ public class SceneAppState extends SimpleAppState {
         setupFilters();
     }
 
+    /**
+     * Preload the assets used in this model.
+     *
+     * @param assetManager for loading assets (not null)
+     */
+    @Override
+    public void load(AssetManager assetManager) {
+        new AudioNode(assetManager, AUDIO_ASSET_PATH, AudioData.DataType.Stream);
+        if (!generateLightProbe) {
+            assetManager.loadModel(LIGHT_ASSET_PATH);
+        }
+        assetManager.loadModel(MODEL_ASSET_PATH);
+        SkyFactory.createSky(assetManager, SKY_ASSET_PATH, SkyFactory.EnvMapType.CubeMap);
+    }
+
     private void setupSkyBox() {
-        Spatial sky = SkyFactory.createSky(assetManager, "Scenes/Beach/FullskiesSunset0068.dds", SkyFactory.EnvMapType.CubeMap);
+        Spatial sky = SkyFactory.createSky(assetManager, SKY_ASSET_PATH, SkyFactory.EnvMapType.CubeMap);
         sky.setShadowMode(RenderQueue.ShadowMode.Off);
         rootNode.attachChild(sky);
     }
 
     private void setupScene() {
-        Spatial scene = assetManager.loadModel("Scenes/level_rough.gltf");
+        Spatial scene = assetManager.loadModel(MODEL_ASSET_PATH);
         scene.setName("MainScene");
         scene.move(0, -5, 0);
         CollisionShape shape = CollisionShapeFactory.createMeshShape(scene);
@@ -62,7 +84,7 @@ public class SceneAppState extends SimpleAppState {
         rootNode.setQueueBucket(RenderQueue.Bucket.Opaque);
 
         /* nature sound - keeps playing in a loop. */
-        AudioNode audio = new AudioNode(assetManager, "Sound/Environment/Nature.ogg", AudioData.DataType.Stream);
+        AudioNode audio = new AudioNode(assetManager, AUDIO_ASSET_PATH, AudioData.DataType.Stream);
         audio.setLooping(true);
         audio.setPositional(false);
         audio.setVolume(2);
@@ -87,7 +109,7 @@ public class SceneAppState extends SimpleAppState {
             
         } else {
             // add a PBR probe.
-            Spatial probeModel = assetManager.loadModel("Scenes/defaultProbe.j3o");
+            Spatial probeModel = assetManager.loadModel(LIGHT_ASSET_PATH);
             LightProbe lightProbe = (LightProbe) probeModel.getLocalLightList().get(0);
             lightProbe.getArea().setRadius(100);
             rootNode.addLight(lightProbe);


### PR DESCRIPTION
The new loading screen plays a simple animation while assets are pre-loaded in the background. You can fast-forward the animation by pressing the Tab key.

Preloading is currently implemented for:
+ Flame.j3o
+ Poison.j3o
+ arrow-impact-2.wav
+ bow-pull.wav
+ Grass-Running-3.wav
+ arrow.glb
+ github-logo.png
+ Erika.j3o

Not yet preloaded:
+ bow.gltf
+ defaultProbe.j3o
+ Drake.glb
+ FullskiesSunset0068.dds
+ level_rough.gltf
+ Nature.ogg
etcetera ...
